### PR TITLE
Entity에서 id 타입을 통일하고, named Lock에 대해 트랜잭션 옵션을 설정합니다.

### DIFF
--- a/src/main/java/org/course/registration/entity/Course.java
+++ b/src/main/java/org/course/registration/entity/Course.java
@@ -3,11 +3,9 @@ package org.course.registration.entity;
 import jakarta.persistence.*;
 
 import lombok.Getter;
-import lombok.Setter;
 
 @Entity
 @Getter
-@Setter
 public class Course {
 
     @Id
@@ -22,4 +20,12 @@ public class Course {
     private int limited; // 수강 정원
 
     private int count; // 현재 정원
+
+    public void increaseCount() {
+        this.count += 1;
+    }
+
+    public void decreaseCount() {
+        this.count = Math.max(0, this.count - 1);
+    }
 }

--- a/src/main/java/org/course/registration/entity/Course.java
+++ b/src/main/java/org/course/registration/entity/Course.java
@@ -10,8 +10,7 @@ public class Course {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "course_id")
-    private int id; // 과목 id
+    private Integer id; // 과목 id
 
     private String name; // 과목 이름
 

--- a/src/main/java/org/course/registration/entity/Enroll.java
+++ b/src/main/java/org/course/registration/entity/Enroll.java
@@ -3,7 +3,9 @@ package org.course.registration.entity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import jakarta.persistence.*;
 
@@ -11,6 +13,7 @@ import jakarta.persistence.*;
 @Table(name = "enroll", uniqueConstraints = {
     @UniqueConstraint(columnNames = {"student_id", "course_id"})
 })
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Enroll {
 

--- a/src/main/java/org/course/registration/entity/Enroll.java
+++ b/src/main/java/org/course/registration/entity/Enroll.java
@@ -17,8 +17,9 @@ import jakarta.persistence.*;
 @Getter
 public class Enroll {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "student_id")

--- a/src/main/java/org/course/registration/entity/Student.java
+++ b/src/main/java/org/course/registration/entity/Student.java
@@ -2,6 +2,7 @@ package org.course.registration.entity;
 
 import jakarta.persistence.*;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,7 +11,7 @@ import java.util.List;
 
 @Getter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Student {
 
     @Id

--- a/src/main/java/org/course/registration/service/EnrollService.java
+++ b/src/main/java/org/course/registration/service/EnrollService.java
@@ -48,7 +48,7 @@ public class EnrollService {
         enrollRepository.save(newEnroll);
 
         // 과목 수강 인원 증가
-        course.setCount(course.getCount() + 1);
+        course.increaseCount();
         courseService.saveOrUpdateCourse(course); // 변경된 course 엔티티를 업데이트
     }
 
@@ -60,13 +60,12 @@ public class EnrollService {
     // 수강 취소
     @Transactional
     public void cancelEnrollment(String studentId, int courseId) {
-        Course course = courseService.findCourseById(courseId);
-
         lockRepository.getLock(String.valueOf(studentId));
+        Course course = courseService.findCourseById(courseId);
         enrollRepository.deleteByStudentIdAndCourseId(studentId, courseId);
+
         // 수강 인원 감소
-        int newCount = Math.max(0, course.getCount() - 1); // 0보다 밑으로 내려가는 거 방지
-        course.setCount(newCount);
+        course.decreaseCount();
         courseService.saveOrUpdateCourse(course); // 변경된 course 엔티티를 업데이트
         lockRepository.releaseLock(String.valueOf(studentId));
     }

--- a/src/main/java/org/course/registration/service/EnrollService.java
+++ b/src/main/java/org/course/registration/service/EnrollService.java
@@ -11,6 +11,7 @@ import org.course.registration.repository.EnrollRepository;
 
 import org.course.registration.repository.LockRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -58,7 +59,7 @@ public class EnrollService {
     }
 
     // 수강 취소
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void cancelEnrollment(String studentId, int courseId) {
         lockRepository.getLock(String.valueOf(studentId));
         Course course = courseService.findCourseById(courseId);


### PR DESCRIPTION
## Description ✍️
* Entity에서 id 타입이 통일되지 않아 이 부분을 수정했습니다.
* named Lock의 경우, 락 획득과 수강 취소 로직이 같은 트랜잭션에 있으면 동시성 보장이 안되어 옵션을 추가했습니다.

## Merge 전 체크 리스트 ✅
- [ ] Backend 컨벤션을 잘 지켰나요?
- [ ] 오류 없이 해당 기능이 잘 동작되나요?
- [ ] 모든 리뷰어의 승인을 받았나요?